### PR TITLE
Change reporting channel to #releng-bots

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,7 +29,7 @@ deploy:
 notifications:
   irc:
     channels:
-      - "irc.mozilla.org#releng"
+      - "irc.mozilla.org#releng-bots"
     on_failure: always
     on_success: change
     template:


### PR DESCRIPTION
#releng will be closed in the following weeks, all bots that we want to keep reporting should be doing their work on #releng-bots channel from now on.